### PR TITLE
Add padding to input fields to not overlap value with € symbol

### DIFF
--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -60,7 +60,6 @@ label {
 .input {
   display: flex;
   position: relative;
-  padding-right: 3em;
 }
 
 .number-input {
@@ -75,6 +74,7 @@ label {
   padding-top: 0;
   padding-bottom: 0;
   padding-right: 1em;
+  box-sizing: border-box;
 }
 .number-input:focus {
   outline: none;

--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -60,6 +60,7 @@ label {
 .input {
   display: flex;
   position: relative;
+  padding-right: 3em;
 }
 
 .number-input {


### PR DESCRIPTION
Entering values to input fields overlapped the values with the € symbol. Added some padding to the inputs to fix it.

**Before**
<img width="291" alt="image" src="https://user-images.githubusercontent.com/2499987/96366740-4eaec880-1152-11eb-9ee3-2dbc5eb597b0.png">

**After**
<img width="273" alt="image" src="https://user-images.githubusercontent.com/2499987/96366795-ae0cd880-1152-11eb-978d-61862b649cdf.png">

